### PR TITLE
Update R5VideoView.commands.android.js

### DIFF
--- a/src/commands/R5VideoView.commands.android.js
+++ b/src/commands/R5VideoView.commands.android.js
@@ -2,7 +2,7 @@ import { NativeModules } from 'react-native'
 import R5PublishType from '../enum/R5VideoView.publishtype'
 
 const { UIManager } = NativeModules
-const { R5VideoView } = UIManager
+const R5VideoView = UIManager.getViewManagerConfig("R5VideoView")
 const { Commands } = R5VideoView
 
 export const subscribe = (handle, streamName) => {


### PR DESCRIPTION
Fix for Issue, directly accessing NativeModules.UIManager is no longer supported.