### PR TITLE
fixed foreground service crash on Android version >= 28

### DIFF
--- a/android/src/main/java/com/red5pro/reactnative/view/PublishService.java
+++ b/android/src/main/java/com/red5pro/reactnative/view/PublishService.java
@@ -1,9 +1,13 @@
 package com.red5pro.reactnative.view;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
 import android.util.Log;
@@ -15,6 +19,7 @@ public class PublishService extends Service {
 	private Notification holderNote;
 	private final PublishServiceBinder mBinder = new PublishServiceBinder();
 
+	private final String NOTIFICATION_CHANNEL_ID = "com.red5pro.reactnative";
 
 	@Nullable
 	@Override
@@ -26,6 +31,15 @@ public class PublishService extends Service {
 	public void onCreate() {
 		Log.d("R5VideoViewLayout", "PublishService:onCreate()");
 		super.onCreate();
+
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+			NotificationChannel notificationChannel = new NotificationChannel(
+					NOTIFICATION_CHANNEL_ID,
+					"Publisher",
+					NotificationManager.IMPORTANCE_LOW);
+			NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+			manager.createNotificationChannel(notificationChannel);
+		}
 	}
 
 	public void setServicableDelegate(PublishServicable servicable) {
@@ -54,7 +68,15 @@ public class PublishService extends Service {
 
 			Log.d("R5VideoViewLayout", "PublishService:setDisplayOn(false)");
 			if (holderNote == null) {
-				holderNote = (new Notification.Builder(getApplicationContext()))
+				Notification.Builder notificationBuilder = null;
+
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+					notificationBuilder = new Notification.Builder(getApplicationContext(), NOTIFICATION_CHANNEL_ID);
+				} else {
+					notificationBuilder = new Notification.Builder(getApplicationContext());
+				}
+
+				holderNote = notificationBuilder
 						.setContentTitle("Red5 Pro")
 						.setContentText("Publishing from the background")
 						.setSmallIcon(android.R.drawable.ic_media_play)

--- a/example/Red5ProVideoViewExample/android/app/src/main/AndroidManifest.xml
+++ b/example/Red5ProVideoViewExample/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature
         android:name="android.hardware.camera"


### PR DESCRIPTION
For Android version >= 28, the app will crash when it trying to call `startForeground(...)`. 
So starting from API 28, we have to create a notification channel, as well as declare the `FOREGROUND_SERVICE` permission