### PR TITLE
Fix yellow box warning

### DIFF
--- a/src/commands/R5VideoView.commands.android.js
+++ b/src/commands/R5VideoView.commands.android.js
@@ -2,7 +2,7 @@ import { NativeModules } from 'react-native'
 import R5PublishType from '../enum/R5VideoView.publishtype'
 
 const { UIManager } = NativeModules
-const { R5VideoView } = UIManager
+const R5VideoView = UIManager.getViewManagerConfig('R5VideoView')
 const { Commands } = R5VideoView
 
 export const subscribe = (handle, streamName) => {


### PR DESCRIPTION
Accessing view manager configs directly off UIManager via UIManager['R5VideoView'] is no longer supported. Use UIManager.getViewManagerConfig('R5VideoView') instead.